### PR TITLE
Fix wrong song duration when pausing / unpausing

### DIFF
--- a/ext/src/main/java/dev/brahmkshatriya/echo/extension/DiscordRPC.kt
+++ b/ext/src/main/java/dev/brahmkshatriya/echo/extension/DiscordRPC.kt
@@ -257,7 +257,7 @@ open class DiscordRPC : ExtensionClient, LoginClient.WebView, TrackerClient,
             .takeIf { it.isNotEmpty() }
         val startTimestamp = System.currentTimeMillis() - details.currentPosition
         val endTimeStamp = (details.totalDuration ?: track.duration)?.let {
-            startTimestamp + it - details.currentPosition
+            startTimestamp + it
         }
         rpc.newActivity(
             Activity(


### PR DESCRIPTION
This is a one-line fix that makes your song duration correctly display when you pause and unpause the song you're playing